### PR TITLE
fix: use lazy initialization for Resend and Redis clients

### DIFF
--- a/voicelite-web/lib/emails/license-email.ts
+++ b/voicelite-web/lib/emails/license-email.ts
@@ -1,6 +1,13 @@
 import { Resend } from 'resend';
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+// Lazy initialization of Resend client to allow builds without env vars
+function getResendClient() {
+  const key = process.env.RESEND_API_KEY;
+  if (!key || key === 're_placeholder') {
+    throw new Error('RESEND_API_KEY must be configured');
+  }
+  return new Resend(key);
+}
 
 export interface LicenseEmailData {
   email: string;
@@ -122,6 +129,7 @@ Need help? Just reply to this email.
 `.trim();
 
   try {
+    const resend = getResendClient();
     const result = await resend.emails.send({
       from: `VoiceLite <${fromEmail}>`,
       to: email,


### PR DESCRIPTION
**Problem**: Build failures on branches without environment variables. Services (Resend, Redis) were initialized at import time, causing builds to fail when env vars were missing.

**Changes**:
1. Resend client (license-email.ts): Moved from top-level const to lazy getResendClient() function called at runtime
2. Redis rate limiter (feedback/submit/route.ts): Moved from top-level const to lazy getRateLimiter() function called at runtime

**Impact**:
- Builds now work without requiring secrets during build phase
- Consistent with existing webhook pattern (getStripeClient)
- Better error messages at runtime with request context
- Enables deployment to test environments without real API keys

**Technical Details**:
- Build time: Files imported → Functions defined (no execution) → Success
- Runtime: Endpoint called → Lazy function executes → Has env vars → Works

🤖 Generated with [Claude Code](https://claude.com/claude-code)