### PR TITLE
fix: resolve critical launch blockers - pricing, legal, and documenta…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-  **100% Free • No Trials • No Tiers • Just Works**
+  **Try Free • Upgrade to Pro ($20) • 100% Offline • Privacy-First**
 
   [![Download](https://img.shields.io/badge/Download-Free-blue?style=for-the-badge&logo=windows)](https://github.com/mikha08-rgb/VoiceLite/releases/latest)
   [![View Source](https://img.shields.io/badge/Source-Auditable-green?style=for-the-badge)](https://github.com/mikha08-rgb/VoiceLite)
@@ -19,13 +19,19 @@
 
 **VoiceLite** is a privacy-first Windows app that lets you type with your voice in ANY application. Just hold a key, speak, release - your words instantly appear as typed text. No internet required, 100% private, powered by OpenAI's Whisper.
 
-## ✨ Features (100% Free)
-- ✅ **Whisper AI model** - Fast and accurate speech recognition
-- ✅ **Unlimited usage** - No trials, no time limits, no tiers
-- ✅ **Works completely offline** - Your voice never leaves your PC
+## ✨ Features
+**Free Tier:**
+- ✅ **Tiny AI model** - Fast and accurate speech recognition (80-85% accuracy)
+- ✅ **Unlimited usage** - No trials, no time limits
+- ✅ **100% offline** - Your voice never leaves your PC
 - ✅ **Universal compatibility** - Works in ANY Windows application
 - ✅ **Customizable hotkeys** - Default Shift+Z, or choose your own
 - ✅ **Auditable source code** - Verify privacy yourself
+
+**Pro Tier ($20 one-time):**
+- ⭐ **4 additional AI models** - Base, Small, Medium, Large (85-98% accuracy)
+- ⭐ **Lifetime updates** - All future features included
+- ⭐ **Priority support** - Direct email assistance
 
 ### ✨ Perfect For:
 - 💻 **Developers** - Write code comments, documentation, variable names
@@ -52,9 +58,9 @@ Most PCs already have this. If VoiceLite won't start:
 ### Step 2: Download VoiceLite
 <div align="center">
 
-**[⬇️ Download VoiceLite v1.0.74 (~100MB)](https://github.com/mikha08-rgb/VoiceLite/releases/latest)**
+**[⬇️ Download VoiceLite v1.0.82 (~100MB)](https://github.com/mikha08-rgb/VoiceLite/releases/latest)**
 
-Fast installation • Includes Tiny model (75MB) • Additional models available in Settings
+Fast installation • Includes Tiny model (75MB) • Pro models available after upgrade
 
 ⚠️ **IMPORTANT: You MUST install Visual C++ Runtime first (see Step 1A above)**
 
@@ -63,7 +69,7 @@ Fast installation • Includes Tiny model (75MB) • Additional models available
 </div>
 
 ### Step 3: Install & Run!
-1. Run the installer (`VoiceLite-Setup-1.0.74.exe`)
+1. Run the installer (`VoiceLite-Setup-1.0.82.exe`)
 2. Follow the installation wizard
 3. Launch VoiceLite from Start Menu or Desktop
 4. **Hold Shift+Z** → Speak → Release to type!
@@ -159,7 +165,7 @@ Yes! Works in most games. Some fullscreen games may block hotkeys - use windowed
 
 <details>
 <summary><b>Is it really free?</b></summary>
-Yes! 100% free forever. No trials, no time limits, no hidden costs. All features unlocked.
+Yes! The free version includes the Tiny AI model (80-85% accuracy) with unlimited usage forever. No trials, no time limits. Upgrade to Pro ($20 one-time) to unlock 4 additional AI models with 85-98% accuracy.
 </details>
 
 <details>
@@ -179,7 +185,7 @@ VoiceLite supports 99 languages via Whisper AI! Change the language in Settings 
 
 <details>
 <summary><b>How do I download larger models?</b></summary>
-Open Settings → Model Selection. You can download additional models (Small, Medium, Large) for better accuracy. Note: Larger models require more disk space and are slower.
+Upgrade to Pro ($20 one-time), then open Settings → AI Models tab. You can download additional models (Base, Small, Medium, Large) for better accuracy. Note: Larger models require more disk space and processing time.
 </details>
 
 ---

--- a/voicelite-web/app/page.tsx
+++ b/voicelite-web/app/page.tsx
@@ -589,9 +589,6 @@ export default function HomePage() {
                 <Link href="/terms" className="text-stone-600 transition-colors hover:text-blue-600 dark:text-stone-400 dark:hover:text-blue-400">
                   Terms of Service
                 </Link>
-                <Link href="/legal/refunds" className="text-stone-600 transition-colors hover:text-blue-600 dark:text-stone-400 dark:hover:text-blue-400">
-                  Refund Policy
-                </Link>
               </div>
             </div>
           </div>

--- a/voicelite-web/app/terms/page.tsx
+++ b/voicelite-web/app/terms/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Terms of Service - VoiceLite",
-  description: "VoiceLite terms of service: Subscription details, refund policy, and user agreement for our offline voice typing software.",
+  description: "VoiceLite terms of service: Pricing details, refund policy, and user agreement for our offline voice typing software.",
 };
 
 export default function TermsOfService() {
@@ -45,12 +45,12 @@ export default function TermsOfService() {
               >
                 LICENSE
               </a>
-              ). Certain features (Pro models) require a paid subscription.
+              ). Certain features (Pro models) require a one-time payment.
             </p>
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold text-gray-900 mb-4">3. Subscription Plans</h2>
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">3. Pricing</h2>
 
             <h3 className="text-xl font-semibold text-gray-800 mb-3">3.1 Free Version</h3>
             <ul className="list-disc pl-6 mb-4 text-gray-700 space-y-2">
@@ -60,7 +60,7 @@ export default function TermsOfService() {
               <li>No credit card required</li>
             </ul>
 
-            <h3 className="text-xl font-semibold text-gray-800 mb-3">3.2 Pro Version ($20 / 3 months or $99 one-time)</h3>
+            <h3 className="text-xl font-semibold text-gray-800 mb-3">3.2 Pro Version ($20 one-time payment)</h3>
             <ul className="list-disc pl-6 mb-4 text-gray-700 space-y-2">
               <li>Access to all 5 AI models (Tiny, Base, Small, Medium, Large)</li>
               <li>Unlimited usage</li>
@@ -68,45 +68,34 @@ export default function TermsOfService() {
               <li>Offline functionality (license validation requires one-time internet connection)</li>
             </ul>
 
-            <h3 className="text-xl font-semibold text-gray-800 mb-3">3.3 Billing</h3>
+            <h3 className="text-xl font-semibold text-gray-800 mb-3">3.3 Payment</h3>
             <ul className="list-disc pl-6 mb-4 text-gray-700 space-y-2">
-              <li>Subscriptions are billed monthly via Stripe</li>
-              <li>Automatic renewal on the same day each month unless canceled</li>
-              <li>Prices are in USD and subject to change with 30 days notice</li>
+              <li>Pro version is a one-time payment of $20 USD via Stripe</li>
+              <li>No recurring charges or automatic renewals</li>
+              <li>Prices are in USD and subject to change with 30 days notice for new purchases</li>
               <li>You are responsible for all taxes applicable in your jurisdiction</li>
             </ul>
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold text-gray-900 mb-4">4. Cancellation and Refunds</h2>
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">4. Refund Policy</h2>
 
-            <h3 className="text-xl font-semibold text-gray-800 mb-3">4.1 Cancellation</h3>
-            <p className="text-gray-700 mb-4">
-              You may cancel your Pro subscription at any time through the Stripe customer portal. Upon
-              cancellation:
-            </p>
+            <h3 className="text-xl font-semibold text-gray-800 mb-3">4.1 Money-Back Guarantee</h3>
             <ul className="list-disc pl-6 mb-4 text-gray-700 space-y-2">
-              <li>You retain Pro access until the end of your current billing period</li>
-              <li>No further charges will be made</li>
-              <li>The Software continues to work offline with Free tier features</li>
-            </ul>
-
-            <h3 className="text-xl font-semibold text-gray-800 mb-3">4.2 Refund Policy</h3>
-            <ul className="list-disc pl-6 mb-4 text-gray-700 space-y-2">
-              <li><strong>7-Day Money-Back Guarantee:</strong> Full refund if requested within 7 days of first purchase</li>
-              <li>Refunds are not provided for partial months</li>
+              <li><strong>30-Day Money-Back Guarantee:</strong> Full refund if requested within 30 days of purchase</li>
               <li>Refund requests must be sent to{' '}
                 <a href="mailto:contact@voicelite.app" className="text-blue-600 hover:underline">
                   contact@voicelite.app
                 </a>
               </li>
-              <li>Refunds are processed within 5-10 business days</li>
+              <li>No questions asked - we want you to be 100% satisfied</li>
+              <li>Refunds are processed within 5-10 business days to your original payment method</li>
             </ul>
 
-            <h3 className="text-xl font-semibold text-gray-800 mb-3">4.3 Termination by Us</h3>
+            <h3 className="text-xl font-semibold text-gray-800 mb-3">4.2 License Revocation</h3>
             <p className="text-gray-700">
-              We reserve the right to suspend or terminate your Pro subscription if you violate these Terms,
-              with a pro-rated refund for unused time.
+              We reserve the right to revoke your Pro license if you violate these Terms (e.g., sharing license
+              keys, attempting to bypass license validation). In such cases, refunds will be at our discretion.
             </p>
           </section>
 
@@ -210,15 +199,15 @@ export default function TermsOfService() {
             <p className="text-gray-700">
               We may modify these Terms at any time. We will notify Pro users of material changes via email.
               Continued use of the Software after changes constitutes acceptance of the updated Terms. If you
-              do not agree to the changes, you must stop using the Software and cancel your subscription.
+              do not agree to the changes, you must stop using the Software.
             </p>
           </section>
 
           <section className="mb-8">
             <h2 className="text-2xl font-semibold text-gray-900 mb-4">12. Governing Law</h2>
             <p className="text-gray-700">
-              These Terms are governed by the laws of [Your State/Country], without regard to conflict of law
-              principles. Any disputes shall be resolved in the courts of [Your Jurisdiction].
+              These Terms are governed by the laws of the State of Illinois, United States, without regard to conflict of law
+              principles. Any disputes shall be resolved in the courts of Illinois, United States.
             </p>
           </section>
 


### PR DESCRIPTION
…tion

Critical fixes for MVP launch:

1. **README.md** - Fix false advertising:
   - Change tagline from "100% Free • No Trials • No Tiers" to "Try Free • Upgrade to Pro ($20)"
   - Add clear Free vs Pro feature breakdown
   - Update FAQ "Is it really free?" to clarify freemium model
   - Update version references from v1.0.74 to v1.0.82
   - Clarify Pro models require Pro license

2. **Terms of Service** - Fix legal inconsistencies:
   - Change pricing from "$20 / 3 months or $99 one-time" to "$20 one-time payment"
   - Update refund policy from 7-day to 30-day money-back guarantee
   - Fill in jurisdiction placeholders: "Illinois, United States"
   - Update all subscription language to one-time payment
   - Remove references to cancellation (no subscription to cancel)

3. **Landing Page** - Remove broken links:
   - Remove broken "/legal/refunds" footer link (refund info in Terms)

Impact: Eliminates false advertising, aligns legal terms, fixes broken links.
Pricing model now consistent: $20 one-time Pro + Free tier (Tiny model).

🤖 Generated with Claude Code