### PR TITLE
feat: add offline translation to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ VoiceLite v2.0 uses **Parakeet TDT 0.6B v3** (~640MB), an NVIDIA transducer mode
 
 The model isn't bundled with the installer. On first launch, VoiceLite downloads it from GitHub Releases and extracts it to `%LocalAppData%\VoiceLite\models\parakeet-v3\`.
 
-Settings also includes an opt-in **Translate to English** mode. It uses NVIDIA Canary 180M Flash to translate Spanish, French, or German speech directly to English on-device. Its separate ~154MB int8 model downloads only when requested.
+Settings also includes an opt-in **Translate to English** mode (Pro). It uses NVIDIA Canary 180M Flash to translate Spanish, French, or German speech directly to English on-device. Its separate ~154MB int8 model downloads only when requested.
 
 ## Features
 
@@ -41,7 +41,7 @@ Settings also includes an opt-in **Translate to English** mode. It uses NVIDIA C
 
 **Offline?** Yes, 100%. Voice never leaves your PC.
 
-**Languages?** Parakeet automatically recognizes 25 European languages. The optional Translate to English mode currently accepts Spanish, French, or German speech.
+**Languages?** Parakeet automatically recognizes 25 European languages. The optional Translate to English mode (Pro) currently accepts Spanish, French, or German speech.
 
 **Works in games?** Yes. Use windowed mode if fullscreen blocks hotkey.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VoiceLite
 
-Windows speech-to-text app. Hold a key, speak, release — text appears wherever your cursor is. 100% offline, powered by [Sherpa-ONNX](https://github.com/k2-fsa/sherpa-onnx) running NVIDIA's [Parakeet TDT 0.6B v3](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) model.
+Windows speech-to-text app. Hold a key, speak, release — text appears wherever your cursor is. 100% offline, powered by [Sherpa-ONNX](https://github.com/k2-fsa/sherpa-onnx) running NVIDIA speech models.
 
 [![Download](https://img.shields.io/github/v/release/mikha08-rgb/VoiceLite)](https://github.com/mikha08-rgb/VoiceLite/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
@@ -28,6 +28,8 @@ VoiceLite v2.0 uses **Parakeet TDT 0.6B v3** (~640MB), an NVIDIA transducer mode
 
 The model isn't bundled with the installer. On first launch, VoiceLite downloads it from GitHub Releases and extracts it to `%LocalAppData%\VoiceLite\models\parakeet-v3\`.
 
+Settings also includes an opt-in **Translate to English** mode. It uses NVIDIA Canary 180M Flash to translate Spanish, French, or German speech directly to English on-device. Its separate ~154MB int8 model downloads only when requested.
+
 ## Features
 
 - Works in any Windows application
@@ -39,7 +41,7 @@ The model isn't bundled with the installer. On first launch, VoiceLite downloads
 
 **Offline?** Yes, 100%. Voice never leaves your PC.
 
-**Languages?** 25 European languages (Parakeet TDT 0.6B v3). Change in Settings → Language.
+**Languages?** Parakeet automatically recognizes 25 European languages. The optional Translate to English mode currently accepts Spanish, French, or German speech.
 
 **Works in games?** Yes. Use windowed mode if fullscreen blocks hotkey.
 
@@ -75,12 +77,13 @@ dotnet publish VoiceLite/VoiceLite/VoiceLite.csproj -c Release -r win-x64 --self
 - .NET 8 / WPF
 - [Sherpa-ONNX](https://github.com/k2-fsa/sherpa-onnx) (speech recognition runtime, in-process via P/Invoke)
 - [Parakeet TDT 0.6B v3](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) (NVIDIA, CC-BY-4.0) — speech model
+- [Canary 180M Flash](https://huggingface.co/nvidia/canary-180m-flash) (NVIDIA, CC-BY-4.0) — optional speech-translation model
 - [Silero VAD](https://github.com/snakers4/silero-vad) (voice activity detection, ONNX)
 - [NAudio](https://github.com/naudio/NAudio) (audio capture)
 
 ## Credits & Attribution
 
-VoiceLite ships the **Parakeet TDT 0.6B v3** model from NVIDIA, used unmodified under the [Creative Commons Attribution 4.0 International (CC-BY-4.0)](https://creativecommons.org/licenses/by/4.0/) license. The full license text and our usage notice are included in the `LICENSES/` directory of the installation. See [model card](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) for model details.
+VoiceLite uses NVIDIA's **Parakeet TDT 0.6B v3** and optional **Canary 180M Flash** models under the [Creative Commons Attribution 4.0 International (CC-BY-4.0)](https://creativecommons.org/licenses/by/4.0/) license. The full license text and usage notices are included in the `LICENSES/` directory of the installation.
 
 ## Contributing
 

--- a/VoiceLite/LICENSES/canary-180m-flash-NOTICE.txt
+++ b/VoiceLite/LICENSES/canary-180m-flash-NOTICE.txt
@@ -1,0 +1,15 @@
+NVIDIA Canary 180M Flash
+========================
+
+VoiceLite optionally downloads and uses NVIDIA's Canary 180M Flash model for
+offline speech translation from Spanish, French, or German to English.
+
+Original model: https://huggingface.co/nvidia/canary-180m-flash
+Sherpa-ONNX conversion: https://github.com/k2-fsa/sherpa-onnx
+License: Creative Commons Attribution 4.0 International (CC BY 4.0)
+License text: CC-BY-4.0.txt in this directory
+
+The downloaded bundle contains an int8 ONNX conversion prepared by the
+sherpa-onnx project. VoiceLite does not modify those model weights.
+
+Canary 180M Flash was created by NVIDIA Corporation.

--- a/VoiceLite/VoiceLite.Tests/Services/SpeechTranslationTests.cs
+++ b/VoiceLite/VoiceLite.Tests/Services/SpeechTranslationTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using VoiceLite.Models;
+using VoiceLite.Services;
+using Xunit;
+
+namespace VoiceLite.Tests.Services
+{
+    public sealed class SpeechTranslationTests : IDisposable
+    {
+        private readonly string modelDir = Path.Combine(
+            Path.GetTempPath(),
+            $"VoiceLite-CanaryConfig-{Guid.NewGuid():N}");
+
+        [Fact]
+        public void Settings_DefaultsKeepExistingTranscriptionBehavior()
+        {
+            var settings = new Settings();
+
+            settings.TranslateToEnglish.Should().BeFalse();
+            settings.TranslationSourceLanguage.Should().Be("es");
+        }
+
+        [Fact]
+        public void SettingsValidator_RepairsUnsupportedTranslationLanguage()
+        {
+            var settings = new Settings { TranslationSourceLanguage = "it" };
+
+            SettingsValidator.ValidateAndRepair(settings)
+                .TranslationSourceLanguage.Should().Be("es");
+        }
+
+        [Theory]
+        [InlineData("es")]
+        [InlineData("fr")]
+        [InlineData("de")]
+        public void SettingsValidator_PreservesSupportedTranslationLanguage(string language)
+        {
+            var settings = new Settings { TranslationSourceLanguage = language };
+
+            SettingsValidator.ValidateAndRepair(settings)
+                .TranslationSourceLanguage.Should().Be(language);
+        }
+
+        [Fact]
+        public void OldSettingsJson_LeavesTranslationDisabled()
+        {
+            var settings = JsonSerializer.Deserialize<Settings>(
+                """{"WhisperModel":"parakeet-tdt-0.6b-v3-int8"}""");
+
+            settings.Should().NotBeNull();
+            settings!.TranslateToEnglish.Should().BeFalse();
+            settings.TranslationSourceLanguage.Should().Be("es");
+        }
+
+        [Fact]
+        public void TranslationSettings_RoundTripThroughSettingsJson()
+        {
+            var original = new Settings
+            {
+                TranslateToEnglish = true,
+                TranslationSourceLanguage = "fr"
+            };
+
+            var json = JsonSerializer.Serialize(original);
+            var reloaded = JsonSerializer.Deserialize<Settings>(json);
+
+            reloaded.Should().NotBeNull();
+            reloaded!.TranslateToEnglish.Should().BeTrue();
+            reloaded.TranslationSourceLanguage.Should().Be("fr");
+        }
+
+        [Fact]
+        public void DownloadEndpoint_ResolvesTranslationModelBundle()
+        {
+            DownloadEndpoints.GetUrlForFileName(TranslationModelResolverService.ModelId)
+                .Should().Be(DownloadEndpoints.CanaryTranslationInt8);
+        }
+
+        [Theory]
+        [InlineData("es", "es")]
+        [InlineData("fr", "fr")]
+        [InlineData("de", "de")]
+        [InlineData("ES", "es")]
+        public void CreateCanaryRecognizerConfig_TargetsEnglishLocally(
+            string sourceLanguage,
+            string expectedSourceLanguage)
+        {
+            WriteRequiredFiles();
+
+            var config = TranscriptionService.CreateCanaryRecognizerConfig(
+                modelDir,
+                sourceLanguage);
+
+            config.ModelConfig.Canary.Encoder.Should().Be(
+                Path.Combine(modelDir, "encoder.int8.onnx"));
+            config.ModelConfig.Canary.Decoder.Should().Be(
+                Path.Combine(modelDir, "decoder.int8.onnx"));
+            config.ModelConfig.Canary.SrcLang.Should().Be(expectedSourceLanguage);
+            config.ModelConfig.Canary.TgtLang.Should().Be("en");
+            config.ModelConfig.Canary.UsePnc.Should().Be(1);
+            config.DecodingMethod.Should().Be("greedy_search");
+        }
+
+        [Fact]
+        public void CreateCanaryRecognizerConfig_RejectsUnsupportedSourceLanguage()
+        {
+            var act = () => TranscriptionService.CreateCanaryRecognizerConfig(modelDir, "it");
+
+            act.Should().Throw<ArgumentException>()
+                .WithMessage("*Unsupported translation source language*");
+        }
+
+        [Fact]
+        public async Task ForeignLanguageSpeech_ProducesEnglishTranslation_WhenFunctionalModelIsAvailable()
+        {
+            // Optional local functional coverage, matching the repository's established
+            // model-dependent test pattern. CI does not download ~154MB just to run it.
+            var testRoot = Environment.GetEnvironmentVariable("VOICELITE_CANARY_TEST_ROOT");
+            var sourceWav = Environment.GetEnvironmentVariable("VOICELITE_CANARY_TEST_WAV");
+            var sourceLanguage = Environment.GetEnvironmentVariable("VOICELITE_CANARY_TEST_LANGUAGE") ?? "es";
+            if (string.IsNullOrWhiteSpace(testRoot) ||
+                string.IsNullOrWhiteSpace(sourceWav) ||
+                !File.Exists(sourceWav))
+            {
+                return;
+            }
+
+            var settings = new Settings
+            {
+                TranslateToEnglish = true,
+                TranslationSourceLanguage = sourceLanguage
+            };
+            var resolver = new TranslationModelResolverService(
+                testRoot,
+                Path.Combine(testRoot, "unused-local-app-data"));
+
+            using var service = new TranscriptionService(
+                settings,
+                translationModelResolver: resolver);
+
+            var result = await service.TranscribeAsync(sourceWav);
+
+            result.Should().NotBeNullOrWhiteSpace();
+            result.Should().ContainAny(
+                "the", "The", "you", "You", "is", "are", "has", "have");
+        }
+
+        private void WriteRequiredFiles()
+        {
+            Directory.CreateDirectory(modelDir);
+            foreach (var fileName in TranslationModelResolverService.RequiredModelFiles)
+            {
+                File.WriteAllText(Path.Combine(modelDir, fileName), "test");
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(modelDir))
+                Directory.Delete(modelDir, recursive: true);
+        }
+    }
+}

--- a/VoiceLite/VoiceLite.Tests/Services/SpeechTranslationTests.cs
+++ b/VoiceLite/VoiceLite.Tests/Services/SpeechTranslationTests.cs
@@ -74,6 +74,33 @@ namespace VoiceLite.Tests.Services
         }
 
         [Fact]
+        public void EffectiveTranslateToEnglish_FreeUser_IsFalse_EvenWhenEnabledInSettings()
+        {
+            var settings = new Settings
+            {
+                IsProLicense = false,
+                TranslateToEnglish = true
+            };
+            using var service = new TranscriptionService(settings);
+
+            service.EffectiveTranslateToEnglish.Should().BeFalse(
+                "Free tier must fall back to normal Parakeet transcription");
+        }
+
+        [Fact]
+        public void EffectiveTranslateToEnglish_ProUser_ReflectsTheSetting()
+        {
+            var settings = new Settings
+            {
+                IsProLicense = true,
+                TranslateToEnglish = true
+            };
+            using var service = new TranscriptionService(settings);
+
+            service.EffectiveTranslateToEnglish.Should().BeTrue();
+        }
+
+        [Fact]
         public void DownloadEndpoint_ResolvesTranslationModelBundle()
         {
             DownloadEndpoints.GetUrlForFileName(TranslationModelResolverService.ModelId)
@@ -131,6 +158,7 @@ namespace VoiceLite.Tests.Services
 
             var settings = new Settings
             {
+                IsProLicense = true, // Translation is Pro-gated
                 TranslateToEnglish = true,
                 TranslationSourceLanguage = sourceLanguage
             };

--- a/VoiceLite/VoiceLite.Tests/Services/TranslationModelResolverServiceTests.cs
+++ b/VoiceLite/VoiceLite.Tests/Services/TranslationModelResolverServiceTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+using AwesomeAssertions;
+using VoiceLite.Services;
+using Xunit;
+
+namespace VoiceLite.Tests.Services
+{
+    public sealed class TranslationModelResolverServiceTests : IDisposable
+    {
+        private readonly string testRoot = Path.Combine(
+            Path.GetTempPath(),
+            $"VoiceLite-TranslationResolver-{Guid.NewGuid():N}");
+
+        [Fact]
+        public void ResolveModelPath_WhenOptionalModelIsMissing_ThrowsActionableError()
+        {
+            var resolver = new TranslationModelResolverService(
+                Path.Combine(testRoot, "app"),
+                Path.Combine(testRoot, "local"));
+
+            var act = () => resolver.ResolveModelPath();
+
+            act.Should().Throw<FileNotFoundException>()
+                .WithMessage("*Install translation model*");
+        }
+
+        [Fact]
+        public void ResolveModelPath_WhenAllFilesArePresent_ReturnsModelDirectory()
+        {
+            var localAppData = Path.Combine(testRoot, "local");
+            var modelDir = Path.Combine(
+                localAppData,
+                "VoiceLite",
+                "models",
+                TranslationModelResolverService.ModelFolderName);
+            WriteRequiredFiles(modelDir);
+
+            var resolver = new TranslationModelResolverService(
+                Path.Combine(testRoot, "app"),
+                localAppData);
+
+            resolver.ResolveModelPath().Should().Be(modelDir);
+            resolver.IsModelInstalled().Should().BeTrue();
+        }
+
+        [Fact]
+        public void HasRequiredFiles_RejectsZeroByteModelFile()
+        {
+            var modelDir = Path.Combine(testRoot, "model");
+            WriteRequiredFiles(modelDir);
+            File.WriteAllBytes(Path.Combine(modelDir, "decoder.int8.onnx"), Array.Empty<byte>());
+
+            TranslationModelResolverService.HasRequiredFiles(modelDir).Should().BeFalse();
+        }
+
+        private static void WriteRequiredFiles(string modelDir)
+        {
+            Directory.CreateDirectory(modelDir);
+            foreach (var fileName in TranslationModelResolverService.RequiredModelFiles)
+            {
+                File.WriteAllText(Path.Combine(modelDir, fileName), "test");
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(testRoot))
+                Directory.Delete(testRoot, recursive: true);
+        }
+    }
+}

--- a/VoiceLite/VoiceLite/Controls/ModelDownloadControl.xaml
+++ b/VoiceLite/VoiceLite/Controls/ModelDownloadControl.xaml
@@ -6,12 +6,14 @@
              mc:Ignorable="d"
              d:DesignHeight="500" d:DesignWidth="600">
     <StackPanel>
-        <TextBlock Text="Speech Recognition Engine"
+        <TextBlock Name="EngineHeaderText"
+                   Text="Speech Recognition Engine"
                    FontSize="14"
                    FontWeight="SemiBold"
                    Margin="0,0,0,15"/>
 
-        <TextBlock Text="Parakeet v3 is the in-process ASR engine. The model is downloaded on first launch and stored locally — nothing leaves your device during transcription."
+        <TextBlock Name="EngineDescriptionText"
+                   Text="Parakeet v3 is the in-process ASR engine. The model is downloaded on first launch and stored locally — nothing leaves your device during transcription."
                    TextWrapping="Wrap"
                    Foreground="Gray"
                    FontSize="11"
@@ -45,6 +47,7 @@
                                         GroupName="ModelSelection"
                                         VerticalAlignment="Center"
                                         Margin="0,0,10,0"
+                                        Visibility="{Binding SelectionVisibility}"
                                         IsEnabled="{Binding CanSelect}"
                                         IsChecked="{Binding IsSelected, Mode=TwoWay}"
                                         Checked="ModelRadio_Checked"/>

--- a/VoiceLite/VoiceLite/Controls/ModelDownloadControl.xaml.cs
+++ b/VoiceLite/VoiceLite/Controls/ModelDownloadControl.xaml.cs
@@ -38,13 +38,8 @@ namespace VoiceLite.Controls
         // download fails with an actionable message instead of hanging forever.
         private const int StallTimeoutSeconds = 60;
 
-        // Disk-space preflight: tarball (~640MB) and extracted model (~700MB) coexist
-        // briefly during install, so require headroom for both plus a safety margin.
-        private const long TarballBytesRequired = 700_000_000;
-        private const long ExtractedBytesRequired = 800_000_000;
-
         // ModelResolverService probes this path (alongside bin/models for dev installs).
-        private static readonly string ModelDir = Path.Combine(
+        private static readonly string ParakeetModelDir = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "VoiceLite", "models", "parakeet-v3");
 
@@ -89,17 +84,32 @@ namespace VoiceLite.Controls
         {
             try
             {
-                foreach (var file in Directory.EnumerateFiles(Path.GetTempPath(), "parakeet-*.tar.bz2"))
+                var tempPatterns = new[]
                 {
-                    try { File.Delete(file); }
-                    catch { /* locked by a concurrent download — leave it */ }
+                    "parakeet-*.tar.bz2",
+                    "canary-translation-*.tar.bz2"
+                };
+                foreach (var pattern in tempPatterns)
+                {
+                    foreach (var file in Directory.EnumerateFiles(Path.GetTempPath(), pattern))
+                    {
+                        try { File.Delete(file); }
+                        catch { /* locked by a concurrent download — leave it */ }
+                    }
                 }
 
-                var parentDir = Path.GetDirectoryName(ModelDir);
-                if (parentDir != null && Directory.Exists(parentDir))
+                foreach (var modelDir in new[]
                 {
+                    ParakeetModelDir,
+                    TranslationModelResolverService.DefaultModelDirectory
+                })
+                {
+                    var parentDir = Path.GetDirectoryName(modelDir);
+                    if (parentDir == null || !Directory.Exists(parentDir))
+                        continue;
+
                     foreach (var dir in Directory.EnumerateDirectories(
-                                 parentDir, Path.GetFileName(ModelDir) + ".tmp-*"))
+                                 parentDir, Path.GetFileName(modelDir) + ".tmp-*"))
                     {
                         try { Directory.Delete(dir, recursive: true); }
                         catch { /* in use — leave it */ }
@@ -115,14 +125,50 @@ namespace VoiceLite.Controls
         // First-launch use passes null settings/callback — the control still functions
         // for the download flow because settings.TranscriptionModel already defaults to the
         // Parakeet id in Models/Settings.cs.
-        public void Initialize(Settings? currentSettings, Action? onSaveSettings = null)
+        public void Initialize(
+            Settings? currentSettings,
+            Action? onSaveSettings = null,
+            bool includeTranslationModel = false)
         {
             settings = currentSettings;
             saveSettingsCallback = onSaveSettings;
+            if (includeTranslationModel && models.All(m => m.FileName != TranslationModelResolverService.ModelId))
+            {
+                models.Add(CreateTranslationModelInfo());
+            }
+            if (includeTranslationModel)
+            {
+                EngineHeaderText.Text = "Local Speech Models";
+                EngineDescriptionText.Text =
+                    "Parakeet handles normal multilingual transcription. The optional Canary add-on translates Spanish, French, or German speech to English. Both run locally after download.";
+            }
             RefreshModelStates();
         }
 
-        public bool IsModelInstalled => AllModelFilesPresent();
+        /// <summary>
+        /// Reconfigures the control for the small modal launched by the translation
+        /// setting. First-launch setup keeps using the default Parakeet-only view.
+        /// </summary>
+        public void ShowTranslationModelOnly()
+        {
+            models.Clear();
+            models.Add(CreateTranslationModelInfo());
+            RefreshModelStates();
+            EngineHeaderText.Text = "English Translation Add-on";
+            EngineDescriptionText.Text =
+                "Canary translates Spanish, French, or German speech directly to English. The model is stored locally and audio never leaves this computer.";
+            TipText.Text = "Install this optional model to translate Spanish, French, or German speech to English without sending audio online.";
+        }
+
+        public bool IsModelInstalled
+        {
+            get
+            {
+                var parakeet = models.FirstOrDefault(
+                    m => m.FileName == "parakeet-tdt-0.6b-v3-int8");
+                return parakeet != null && AllModelFilesPresent(parakeet);
+            }
+        }
 
         private void InitializeModels()
         {
@@ -132,28 +178,50 @@ namespace VoiceLite.Controls
                 DisplayName = "Parakeet v3 (int8)",
                 Description = "Multilingual (25 EU languages), transducer architecture — no silence hallucinations. ~640MB download.",
                 FileSizeMB = 640,
-                DownloadUrl = DownloadEndpoints.ParakeetV3Int8
+                DownloadUrl = DownloadEndpoints.ParakeetV3Int8,
+                ModelDirectory = ParakeetModelDir,
+                RequiredFiles = RequiredModelFiles,
+                TempFilePrefix = "parakeet",
+                TarballBytesRequired = 700_000_000,
+                ExtractedBytesRequired = 800_000_000,
+                IsSelectable = true
             });
         }
+
+        private static ModelInfo CreateTranslationModelInfo() => new ModelInfo
+        {
+            FileName = TranslationModelResolverService.ModelId,
+            DisplayName = "English Translation Add-on (Canary int8)",
+            Description = "Offline Spanish, French, and German speech → English. Optional ~154MB download.",
+            FileSizeMB = 154,
+            DownloadUrl = DownloadEndpoints.CanaryTranslationInt8,
+            ModelDirectory = TranslationModelResolverService.DefaultModelDirectory,
+            RequiredFiles = TranslationModelResolverService.RequiredModelFiles,
+            TempFilePrefix = "canary-translation",
+            TarballBytesRequired = 200_000_000,
+            ExtractedBytesRequired = 250_000_000,
+            IsSelectable = false
+        };
 
         private void RefreshModelStates()
         {
             foreach (var model in models)
             {
-                model.IsInstalled = AllModelFilesPresent();
-                if (settings != null)
+                model.IsInstalled = AllModelFilesPresent(model);
+                if (settings != null && model.IsSelectable)
                 {
                     model.IsSelected = settings.TranscriptionModel == model.FileName;
                 }
             }
         }
 
-        private static bool AllModelFilesPresent() => AllModelFilesPresentIn(ModelDir);
+        private static bool AllModelFilesPresent(ModelInfo model) =>
+            AllModelFilesPresentIn(model.ModelDirectory, model.RequiredFiles);
 
-        private static bool AllModelFilesPresentIn(string dir)
+        private static bool AllModelFilesPresentIn(string dir, IReadOnlyCollection<string> requiredFiles)
         {
             if (!Directory.Exists(dir)) return false;
-            return RequiredModelFiles.All(f =>
+            return requiredFiles.All(f =>
             {
                 var path = Path.Combine(dir, f);
                 return File.Exists(path) && new FileInfo(path).Length > 0;
@@ -221,11 +289,15 @@ namespace VoiceLite.Controls
                 model.IsDownloading = true;
                 model.DownloadProgress = 0;
 
-                var parentDir = Path.GetDirectoryName(ModelDir)!;
+                var parentDir = Path.GetDirectoryName(model.ModelDirectory)!;
                 Directory.CreateDirectory(parentDir);
-                tempTarPath = Path.Combine(Path.GetTempPath(), $"parakeet-{Guid.NewGuid():N}.tar.bz2");
+                tempTarPath = Path.Combine(Path.GetTempPath(), $"{model.TempFilePrefix}-{Guid.NewGuid():N}.tar.bz2");
 
-                EnsureSufficientDiskSpace(tempTarPath, parentDir);
+                EnsureSufficientDiskSpace(
+                    tempTarPath,
+                    parentDir,
+                    model.TarballBytesRequired,
+                    model.ExtractedBytesRequired);
 
                 // Stall detector: stallCts trips if a single connect/read makes no
                 // progress for StallTimeoutSeconds. The HttpClient itself has an
@@ -269,12 +341,13 @@ namespace VoiceLite.Controls
                 // loss / disk full: partial files made the dir look "installed" and
                 // wedged every subsequent launch.
                 tempExtractDir = Path.Combine(
-                    parentDir, $"{Path.GetFileName(ModelDir)}.tmp-{Guid.NewGuid():N}");
+                    parentDir, $"{Path.GetFileName(model.ModelDirectory)}.tmp-{Guid.NewGuid():N}");
                 var extractDir = tempExtractDir;
-                await Task.Run(() => ExtractRequiredFiles(tempTarPath, extractDir), cts.Token);
+                await Task.Run(() => ExtractRequiredFiles(
+                    tempTarPath, extractDir, model.RequiredFiles), cts.Token);
                 cts.Token.ThrowIfCancellationRequested();
 
-                if (!AllModelFilesPresentIn(tempExtractDir))
+                if (!AllModelFilesPresentIn(tempExtractDir, model.RequiredFiles))
                 {
                     throw new InvalidOperationException(
                         $"Extraction completed but required files are missing or empty in {tempExtractDir}");
@@ -283,15 +356,15 @@ namespace VoiceLite.Controls
                 // Swap: remove any previous (possibly corrupt) live dir, then move the
                 // fully-verified temp dir into place. Same-volume Directory.Move means a
                 // crash leaves either the old state or the complete new state, never a mix.
-                if (Directory.Exists(ModelDir))
-                    Directory.Delete(ModelDir, recursive: true);
-                Directory.Move(tempExtractDir, ModelDir);
+                if (Directory.Exists(model.ModelDirectory))
+                    Directory.Delete(model.ModelDirectory, recursive: true);
+                Directory.Move(tempExtractDir, model.ModelDirectory);
                 tempExtractDir = null; // swapped into place — nothing to clean up
 
-                if (!AllModelFilesPresent())
+                if (!AllModelFilesPresent(model))
                 {
                     throw new InvalidOperationException(
-                        $"Model install verification failed after swap in {ModelDir}");
+                        $"Model install verification failed after swap in {model.ModelDirectory}");
                 }
 
                 model.DownloadProgress = 100;
@@ -309,12 +382,12 @@ namespace VoiceLite.Controls
                 // User closed the window / cancelled: stop cleanly, no error dialog.
                 model.IsDownloading = false;
                 model.DownloadProgress = 0;
-                ErrorLogger.LogDebug("Parakeet download cancelled");
+                ErrorLogger.LogDebug($"{model.DisplayName} download cancelled");
             }
             catch (Exception ex)
             {
                 model.IsDownloading = false;
-                ErrorLogger.LogError("Parakeet download/extract failed", ex);
+                ErrorLogger.LogError($"{model.DisplayName} download/extract failed", ex);
                 MessageBox.Show(
                     $"Failed to install {model.DisplayName}:\n{ex.Message}\n\nClick Download to retry.",
                     "Download Error", MessageBoxButton.OK, MessageBoxImage.Error);
@@ -358,7 +431,11 @@ namespace VoiceLite.Controls
         // Preflight so a full disk produces a clear message with numbers instead of a
         // raw IOException at 99%. Tarball lands on the temp drive; extraction and the
         // final swap happen on the model drive — usually the same drive (C:).
-        private static void EnsureSufficientDiskSpace(string tempFilePath, string targetDir)
+        private static void EnsureSufficientDiskSpace(
+            string tempFilePath,
+            string targetDir,
+            long tarballBytesRequired,
+            long extractedBytesRequired)
         {
             try
             {
@@ -369,12 +446,12 @@ namespace VoiceLite.Controls
 
                 var requirements = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase)
                 {
-                    [tempRoot] = TarballBytesRequired
+                    [tempRoot] = tarballBytesRequired
                 };
                 if (requirements.ContainsKey(targetRoot))
-                    requirements[targetRoot] += ExtractedBytesRequired;
+                    requirements[targetRoot] += extractedBytesRequired;
                 else
-                    requirements[targetRoot] = ExtractedBytesRequired;
+                    requirements[targetRoot] = extractedBytesRequired;
 
                 foreach (var (root, requiredBytes) in requirements)
                 {
@@ -411,12 +488,16 @@ namespace VoiceLite.Controls
             }
         }
 
-        // Tarball nests the 4 files under "sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8/".
-        // We match by filename only so a folder-naming change upstream doesn't break us.
-        private static void ExtractRequiredFiles(string tarBz2Path, string targetDir)
+        // Both upstream bundles nest their files under a model-specific directory.
+        // Match only the required filenames so upstream folder-name changes do not
+        // break either the Parakeet or Canary installer.
+        private static void ExtractRequiredFiles(
+            string tarBz2Path,
+            string targetDir,
+            IReadOnlyCollection<string> requiredFiles)
         {
             Directory.CreateDirectory(targetDir);
-            var wanted = new HashSet<string>(RequiredModelFiles, StringComparer.OrdinalIgnoreCase);
+            var wanted = new HashSet<string>(requiredFiles, StringComparer.OrdinalIgnoreCase);
 
             using var archive = ArchiveFactory.OpenArchive(tarBz2Path, new SharpCompress.Readers.ReaderOptions());
             foreach (var entry in archive.Entries)
@@ -444,9 +525,16 @@ namespace VoiceLite.Controls
         public string Description { get; set; } = string.Empty;
         public int FileSizeMB { get; set; }
         public string? DownloadUrl { get; set; }
+        public string ModelDirectory { get; set; } = string.Empty;
+        public IReadOnlyCollection<string> RequiredFiles { get; set; } = Array.Empty<string>();
+        public string TempFilePrefix { get; set; } = "model";
+        public long TarballBytesRequired { get; set; }
+        public long ExtractedBytesRequired { get; set; }
+        public bool IsSelectable { get; set; } = true;
 
         // Single-engine post-Parakeet swap — no Pro gating, no lock state.
-        public bool CanSelect => IsInstalled;
+        public bool CanSelect => IsSelectable && IsInstalled;
+        public Visibility SelectionVisibility => IsSelectable ? Visibility.Visible : Visibility.Collapsed;
 
         public bool IsInstalled
         {

--- a/VoiceLite/VoiceLite/MainWindow.xaml.cs
+++ b/VoiceLite/VoiceLite/MainWindow.xaml.cs
@@ -1491,7 +1491,9 @@ namespace VoiceLite
                             Text = processedText,           // Processed text (what user sees)
                             OriginalText = transcription,   // Original engine output (for re-injection)
                             Timestamp = DateTime.Now,
-                            ModelUsed = settings.TranscriptionModel
+                            ModelUsed = settings.TranslateToEnglish
+                                ? TranslationModelResolverService.ModelId
+                                : settings.TranscriptionModel
                         };
                         historyService?.AddToHistory(historyItem);
                         _ = UpdateHistoryUI();
@@ -1581,7 +1583,9 @@ namespace VoiceLite
                     (ex is FileNotFoundException or DirectoryNotFoundException or InvalidOperationException
                         && ex.Message.Contains("model", StringComparison.OrdinalIgnoreCase))
                     ? ex.Message
-                    : "Transcription error";
+                    : settings.TranslateToEnglish
+                        ? "Translation error"
+                        : "Transcription error";
 
                 await Dispatcher.InvokeAsync(() =>
                 {

--- a/VoiceLite/VoiceLite/MainWindow.xaml.cs
+++ b/VoiceLite/VoiceLite/MainWindow.xaml.cs
@@ -1491,7 +1491,7 @@ namespace VoiceLite
                             Text = processedText,           // Processed text (what user sees)
                             OriginalText = transcription,   // Original engine output (for re-injection)
                             Timestamp = DateTime.Now,
-                            ModelUsed = settings.TranslateToEnglish
+                            ModelUsed = transcriptionService?.EffectiveTranslateToEnglish == true
                                 ? TranslationModelResolverService.ModelId
                                 : settings.TranscriptionModel
                         };
@@ -1583,7 +1583,7 @@ namespace VoiceLite
                     (ex is FileNotFoundException or DirectoryNotFoundException or InvalidOperationException
                         && ex.Message.Contains("model", StringComparison.OrdinalIgnoreCase))
                     ? ex.Message
-                    : settings.TranslateToEnglish
+                    : transcriptionService?.EffectiveTranslateToEnglish == true
                         ? "Translation error"
                         : "Transcription error";
 

--- a/VoiceLite/VoiceLite/Models/Settings.cs
+++ b/VoiceLite/VoiceLite/Models/Settings.cs
@@ -115,6 +115,11 @@ namespace VoiceLite.Models
         public bool MinimizeToTray { get; set; } = true;
         // Legacy: kept for settings.json compat; UI removed 2026-07-17, Parakeet auto-detects language.
         public string Language { get; set; } = "en";
+        // Optional local speech translation. Off by default so upgrades preserve the
+        // existing multilingual transcription behavior. Canary requires an explicit
+        // source language; the first supported set is Spanish, French, and German.
+        public bool TranslateToEnglish { get; set; } = false;
+        public string TranslationSourceLanguage { get; set; } = "es";
         public int SelectedMicrophoneIndex { get; set; } = -1; // -1 = default device
         public string? SelectedMicrophoneName { get; set; }
         public bool AutoPaste { get; set; } = true;
@@ -158,6 +163,15 @@ namespace VoiceLite.Models
             if (!validLanguages.Contains(settings.Language))
             {
                 settings.Language = "en";
+            }
+
+            var validTranslationLanguages = new HashSet<string>
+            {
+                "es", "fr", "de"
+            };
+            if (!validTranslationLanguages.Contains(settings.TranslationSourceLanguage))
+            {
+                settings.TranslationSourceLanguage = "es";
             }
 
             // Validate microphone index

--- a/VoiceLite/VoiceLite/Services/DownloadEndpoints.cs
+++ b/VoiceLite/VoiceLite/Services/DownloadEndpoints.cs
@@ -1,7 +1,7 @@
 namespace VoiceLite.Services
 {
     /// <summary>
-    /// Centralized download URL for the Parakeet TDT v3 model bundle (Sherpa-ONNX format).
+    /// Centralized download URLs for VoiceLite's Sherpa-ONNX model bundles.
     /// Hosting changes or integrity audits only need to touch this file.
     /// </summary>
     public static class DownloadEndpoints
@@ -24,11 +24,23 @@ namespace VoiceLite.Services
             "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8.tar.bz2";
 
         /// <summary>
+        /// Optional local speech-translation model. The int8 bundle is about 154MB
+        /// and translates Spanish, French, or German speech directly to English.
+        /// </summary>
+        /// <remarks>
+        /// TODO: mirror this bundle on VoiceLite-controlled hosting for the same
+        /// availability reason documented on <see cref="ParakeetV3Int8"/>.
+        /// </remarks>
+        public const string CanaryTranslationInt8 =
+            "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-nemo-canary-180m-flash-en-es-de-fr-int8.tar.bz2";
+
+        /// <summary>
         /// Resolves a canonical model id to its download URL, or null if unsupported.
         /// </summary>
         public static string? GetUrlForFileName(string fileName) => fileName switch
         {
             "parakeet-tdt-0.6b-v3-int8" => ParakeetV3Int8,
+            TranslationModelResolverService.ModelId => CanaryTranslationInt8,
             _ => null,
         };
     }

--- a/VoiceLite/VoiceLite/Services/ProFeatureService.cs
+++ b/VoiceLite/VoiceLite/Services/ProFeatureService.cs
@@ -59,6 +59,13 @@ namespace VoiceLite.Services
         public Visibility CustomDictionaryTabVisibility => IsProUser ? Visibility.Visible : Visibility.Collapsed;
 
         /// <summary>
+        /// Translate to English (Canary add-on model) — Pro feature. The runtime gate
+        /// lives in TranscriptionService.EffectiveTranslateToEnglish; this only controls
+        /// the Settings UI.
+        /// </summary>
+        public Visibility SpeechTranslationVisibility => IsProUser ? Visibility.Visible : Visibility.Collapsed;
+
+        /// <summary>
         /// Advanced Settings - Reserved for future Pro feature.
         /// Visibility infrastructure ready for transcription parameter fine-tuning (beam size, temperature).
         /// </summary>

--- a/VoiceLite/VoiceLite/Services/TranscriptionService.cs
+++ b/VoiceLite/VoiceLite/Services/TranscriptionService.cs
@@ -49,6 +49,12 @@ namespace VoiceLite.Services
         internal IReadOnlyList<CustomDictionaryEntry>? EffectiveCustomDictionary =>
             proFeatureService.IsProUser ? settings.CustomDictionary : null;
 
+        // Translate-to-English is Pro-gated the same way: the Settings toggle is hidden
+        // for Free tier, and this runtime check makes a hand-edited settings.json fall
+        // back to normal Parakeet transcription instead of unlocking translation.
+        internal bool EffectiveTranslateToEnglish =>
+            proFeatureService.IsProUser && settings.TranslateToEnglish;
+
         private volatile bool isDisposed = false;
         private volatile bool isProcessing = false;
 
@@ -92,7 +98,7 @@ namespace VoiceLite.Services
                     if (isDisposed)
                         return;
 
-                    var translateToEnglish = settings.TranslateToEnglish;
+                    var translateToEnglish = EffectiveTranslateToEnglish;
                     var modelDir = translateToEnglish
                         ? this.translationModelResolver.ResolveModelPath()
                         : this.modelResolver.ResolveModelPath();
@@ -271,7 +277,7 @@ namespace VoiceLite.Services
             using var stream = new MemoryStream(audioData);
             return await TranscribeFromStreamAsync(
                 stream,
-                translateToEnglish: settings.TranslateToEnglish,
+                translateToEnglish: EffectiveTranslateToEnglish,
                 translationSourceLanguage: settings.TranslationSourceLanguage);
         }
 
@@ -281,7 +287,7 @@ namespace VoiceLite.Services
             if (!ValidateAudioFile(audioFilePath))
                 return string.Empty;
 
-            var translateToEnglish = settings.TranslateToEnglish;
+            var translateToEnglish = EffectiveTranslateToEnglish;
             var modelDir = translateToEnglish
                 ? translationModelResolver.ResolveModelPath()
                 : modelResolver.ResolveModelPath();
@@ -513,13 +519,13 @@ namespace VoiceLite.Services
         {
             try
             {
-                var modelDir = settings.TranslateToEnglish
+                var modelDir = EffectiveTranslateToEnglish
                     ? translationModelResolver.ResolveModelPath()
                     : modelResolver.ResolveModelPath();
                 if (string.IsNullOrEmpty(modelDir) || !Directory.Exists(modelDir))
                 {
                     TranscriptionError?.Invoke(this, new DirectoryNotFoundException(
-                        settings.TranslateToEnglish
+                        EffectiveTranslateToEnglish
                             ? "Translation model directory not found"
                             : "Parakeet model directory not found"));
                     return false;
@@ -537,7 +543,7 @@ namespace VoiceLite.Services
         {
             try
             {
-                var engine = settings.TranslateToEnglish
+                var engine = EffectiveTranslateToEnglish
                     ? "Canary 180M Flash Translation"
                     : "Parakeet TDT v3";
                 return $"Sherpa-ONNX {typeof(OfflineRecognizer).Assembly.GetName().Version} ({engine})";

--- a/VoiceLite/VoiceLite/Services/TranscriptionService.cs
+++ b/VoiceLite/VoiceLite/Services/TranscriptionService.cs
@@ -19,6 +19,7 @@ namespace VoiceLite.Services
         private readonly Settings settings;
         private readonly string baseDir;
         private readonly ModelResolverService modelResolver;
+        private readonly TranslationModelResolverService translationModelResolver;
         private readonly ProFeatureService proFeatureService;
         private readonly SemaphoreSlim transcriptionSemaphore = new(1, 1);
         private CancellationTokenSource transcriptionCts = new();
@@ -30,7 +31,12 @@ namespace VoiceLite.Services
         // so it is part of the reload key — otherwise preset changes are silent no-ops
         // until restart (single model means modelDir alone never changes).
         private TranscriptionPreset? currentPreset;
+        private bool? currentTranslationMode;
+        private string? currentTranslationSourceLanguage;
         private readonly object recognizerLock = new();
+
+        private static readonly HashSet<string> SupportedTranslationLanguages =
+            new(StringComparer.OrdinalIgnoreCase) { "es", "fr", "de" };
 
         // Test observability: how many times a recognizer has been built.
         internal int RecognizerLoadCount { get; private set; }
@@ -49,11 +55,17 @@ namespace VoiceLite.Services
         public bool IsProcessing => isProcessing;
         public event EventHandler<Exception>? TranscriptionError;
 
-        public TranscriptionService(Settings settings, ModelResolverService? modelResolver = null, ProFeatureService? proFeatureService = null)
+        public TranscriptionService(
+            Settings settings,
+            ModelResolverService? modelResolver = null,
+            ProFeatureService? proFeatureService = null,
+            TranslationModelResolverService? translationModelResolver = null)
         {
             this.settings = settings ?? throw new ArgumentNullException(nameof(settings));
             baseDir = AppDomain.CurrentDomain.BaseDirectory;
             this.modelResolver = modelResolver ?? new ModelResolverService(baseDir, proFeatureService);
+            this.translationModelResolver = translationModelResolver ??
+                new TranslationModelResolverService(baseDir);
             // Same tier check the Settings UI uses to show/hide the Custom Dictionary tab
             // (ProFeatureService.IsProUser reads settings.IsProLicense).
             this.proFeatureService = proFeatureService ?? new ProFeatureService(settings);
@@ -80,8 +92,14 @@ namespace VoiceLite.Services
                     if (isDisposed)
                         return;
 
-                    var modelDir = this.modelResolver.ResolveModelPath();
-                    EnsureRecognizerLoaded(modelDir);
+                    var translateToEnglish = settings.TranslateToEnglish;
+                    var modelDir = translateToEnglish
+                        ? this.translationModelResolver.ResolveModelPath()
+                        : this.modelResolver.ResolveModelPath();
+                    EnsureRecognizerLoaded(
+                        modelDir,
+                        translateToEnglish,
+                        settings.TranslationSourceLanguage);
                 }
                 catch (Exception ex)
                 {
@@ -105,7 +123,10 @@ namespace VoiceLite.Services
             });
         }
 
-        private void EnsureRecognizerLoaded(string modelDir)
+        private void EnsureRecognizerLoaded(
+            string modelDir,
+            bool translateToEnglish,
+            string translationSourceLanguage)
         {
             lock (recognizerLock)
             {
@@ -115,52 +136,126 @@ namespace VoiceLite.Services
                 if (isDisposed)
                     return;
 
-                var preset = settings.TranscriptionPreset;
+                TranscriptionPreset? preset = translateToEnglish
+                    ? null
+                    : settings.TranscriptionPreset;
 
-                if (currentModelDir == modelDir && currentPreset == preset && recognizer != null)
+                if (currentModelDir == modelDir &&
+                    currentPreset == preset &&
+                    currentTranslationMode == translateToEnglish &&
+                    string.Equals(
+                        currentTranslationSourceLanguage,
+                        translateToEnglish ? translationSourceLanguage : null,
+                        StringComparison.OrdinalIgnoreCase) &&
+                    recognizer != null)
                     return;
 
                 if (recognizer != null)
                 {
-                    ErrorLogger.LogMessage($"Reloading Parakeet recognizer: dir {currentModelDir} -> {modelDir}, preset {currentPreset} -> {preset}");
+                    ErrorLogger.LogMessage(
+                        $"Reloading speech recognizer: dir {currentModelDir} -> {modelDir}, " +
+                        $"translation {currentTranslationMode} -> {translateToEnglish}, " +
+                        $"source {currentTranslationSourceLanguage} -> {translationSourceLanguage}, " +
+                        $"preset {currentPreset} -> {preset}");
                     try { recognizer.Dispose(); }
                     catch (Exception ex) { ErrorLogger.LogDebug($"OfflineRecognizer disposal failed during switch: {ex.Message}"); }
                     recognizer = null;
                 }
 
-                var encoder = Path.Combine(modelDir, "encoder.int8.onnx");
-                var decoder = Path.Combine(modelDir, "decoder.int8.onnx");
-                var joiner = Path.Combine(modelDir, "joiner.int8.onnx");
-                var tokens = Path.Combine(modelDir, "tokens.txt");
-
-                foreach (var f in new[] { encoder, decoder, joiner, tokens })
+                OfflineRecognizerConfig config;
+                if (translateToEnglish)
                 {
-                    if (!File.Exists(f))
-                        throw new FileNotFoundException($"Parakeet model file missing: {f}");
+                    config = CreateCanaryRecognizerConfig(modelDir, translationSourceLanguage);
+                    ErrorLogger.LogMessage(
+                        $"Loading Canary translation model: dir={modelDir}, " +
+                        $"source={translationSourceLanguage}, target=en");
+                }
+                else
+                {
+                    var encoder = Path.Combine(modelDir, "encoder.int8.onnx");
+                    var decoder = Path.Combine(modelDir, "decoder.int8.onnx");
+                    var joiner = Path.Combine(modelDir, "joiner.int8.onnx");
+                    var tokens = Path.Combine(modelDir, "tokens.txt");
+
+                    foreach (var f in new[] { encoder, decoder, joiner, tokens })
+                    {
+                        if (!File.Exists(f))
+                            throw new FileNotFoundException($"Parakeet model file missing: {f}");
+                    }
+
+                    var presetConfig = TranscriptionPresetConfig.GetPresetConfig(preset!.Value);
+
+                    config = new OfflineRecognizerConfig();
+                    config.FeatConfig.SampleRate = 16000;
+                    config.FeatConfig.FeatureDim = 80;
+                    config.ModelConfig.Tokens = tokens;
+                    config.ModelConfig.Transducer.Encoder = encoder;
+                    config.ModelConfig.Transducer.Decoder = decoder;
+                    config.ModelConfig.Transducer.Joiner = joiner;
+                    config.ModelConfig.NumThreads = 4;
+                    config.ModelConfig.Provider = "cpu";
+                    config.ModelConfig.Debug = 0;
+                    config.DecodingMethod = presetConfig.DecodingMethod;
+                    config.MaxActivePaths = presetConfig.MaxActivePaths;
+
+                    ErrorLogger.LogMessage($"Loading Parakeet model: dir={modelDir}, decoding={config.DecodingMethod}, beam={config.MaxActivePaths}");
                 }
 
-                var presetConfig = TranscriptionPresetConfig.GetPresetConfig(preset);
-
-                var config = new OfflineRecognizerConfig();
-                config.FeatConfig.SampleRate = 16000;
-                config.FeatConfig.FeatureDim = 80;
-                config.ModelConfig.Tokens = tokens;
-                config.ModelConfig.Transducer.Encoder = encoder;
-                config.ModelConfig.Transducer.Decoder = decoder;
-                config.ModelConfig.Transducer.Joiner = joiner;
-                config.ModelConfig.NumThreads = 4;
-                config.ModelConfig.Provider = "cpu";
-                config.ModelConfig.Debug = 0;
-                config.DecodingMethod = presetConfig.DecodingMethod;
-                config.MaxActivePaths = presetConfig.MaxActivePaths;
-
-                ErrorLogger.LogMessage($"Loading Parakeet model: dir={modelDir}, decoding={config.DecodingMethod}, beam={config.MaxActivePaths}");
                 recognizer = new OfflineRecognizer(config);
                 currentModelDir = modelDir;
                 currentPreset = preset;
+                currentTranslationMode = translateToEnglish;
+                currentTranslationSourceLanguage = translateToEnglish
+                    ? translationSourceLanguage
+                    : null;
                 RecognizerLoadCount++;
-                ErrorLogger.LogMessage("Parakeet model loaded successfully");
+                ErrorLogger.LogMessage(translateToEnglish
+                    ? "Canary translation model loaded successfully"
+                    : "Parakeet model loaded successfully");
             }
+        }
+
+        internal static OfflineRecognizerConfig CreateCanaryRecognizerConfig(
+            string modelDir,
+            string sourceLanguage)
+        {
+            if (!SupportedTranslationLanguages.Contains(sourceLanguage))
+            {
+                throw new ArgumentException(
+                    $"Unsupported translation source language: {sourceLanguage}. " +
+                    "Supported languages are Spanish (es), French (fr), and German (de).",
+                    nameof(sourceLanguage));
+            }
+
+            // Canary task tokens are lowercase even though validation is intentionally
+            // case-insensitive for settings loaded from hand-edited JSON.
+            sourceLanguage = sourceLanguage.ToLowerInvariant();
+
+            var encoder = Path.Combine(modelDir, "encoder.int8.onnx");
+            var decoder = Path.Combine(modelDir, "decoder.int8.onnx");
+            var tokens = Path.Combine(modelDir, "tokens.txt");
+
+            foreach (var file in new[] { encoder, decoder, tokens })
+            {
+                if (!File.Exists(file))
+                    throw new FileNotFoundException($"Canary translation model file missing: {file}");
+            }
+
+            var config = new OfflineRecognizerConfig();
+            config.FeatConfig.SampleRate = 16000;
+            config.FeatConfig.FeatureDim = 80;
+            config.ModelConfig.Tokens = tokens;
+            config.ModelConfig.Canary.Encoder = encoder;
+            config.ModelConfig.Canary.Decoder = decoder;
+            config.ModelConfig.Canary.SrcLang = sourceLanguage;
+            config.ModelConfig.Canary.TgtLang = "en";
+            config.ModelConfig.Canary.UsePnc = 1;
+            config.ModelConfig.NumThreads = 4;
+            config.ModelConfig.Provider = "cpu";
+            config.ModelConfig.Debug = 0;
+            config.DecodingMethod = "greedy_search";
+            config.MaxActivePaths = 1;
+            return config;
         }
 
         public async Task<string> TranscribeFromMemoryAsync(byte[] audioData)
@@ -174,13 +269,29 @@ namespace VoiceLite.Services
             }
 
             using var stream = new MemoryStream(audioData);
-            return await TranscribeFromStreamAsync(stream);
+            return await TranscribeFromStreamAsync(
+                stream,
+                translateToEnglish: settings.TranslateToEnglish,
+                translationSourceLanguage: settings.TranslationSourceLanguage);
         }
 
         // Backward compatibility overload.
         public async Task<string> TranscribeAsync(string audioFilePath)
         {
-            return await TranscribeAsync(audioFilePath, modelResolver.ResolveModelPath());
+            if (!ValidateAudioFile(audioFilePath))
+                return string.Empty;
+
+            var translateToEnglish = settings.TranslateToEnglish;
+            var modelDir = translateToEnglish
+                ? translationModelResolver.ResolveModelPath()
+                : modelResolver.ResolveModelPath();
+
+            using var fileStream = File.OpenRead(audioFilePath);
+            return await TranscribeFromStreamAsync(
+                fileStream,
+                modelDir,
+                translateToEnglish,
+                settings.TranslationSourceLanguage);
         }
 
         public async Task<string> TranscribeAsync(string audioFilePath, string modelDir)
@@ -189,10 +300,18 @@ namespace VoiceLite.Services
                 return string.Empty;
 
             using var fileStream = File.OpenRead(audioFilePath);
-            return await TranscribeFromStreamAsync(fileStream, modelDir);
+            return await TranscribeFromStreamAsync(
+                fileStream,
+                modelDir,
+                translateToEnglish: false,
+                translationSourceLanguage: settings.TranslationSourceLanguage);
         }
 
-        private async Task<string> TranscribeFromStreamAsync(Stream audioStream, string? modelDir = null)
+        private async Task<string> TranscribeFromStreamAsync(
+            Stream audioStream,
+            string? modelDir = null,
+            bool translateToEnglish = false,
+            string translationSourceLanguage = "es")
         {
             if (isDisposed)
                 throw new ObjectDisposedException(nameof(TranscriptionService));
@@ -215,14 +334,21 @@ namespace VoiceLite.Services
                 isProcessing = true;
                 var startTime = DateTime.Now;
 
-                var effectiveModelDir = modelDir ?? modelResolver.ResolveModelPath();
+                var effectiveModelDir = modelDir ?? (translateToEnglish
+                    ? translationModelResolver.ResolveModelPath()
+                    : modelResolver.ResolveModelPath());
                 // Model load/rebuild is seconds of blocking native work (esp. after a preset
                 // change forces a rebuild) — keep it off the caller's thread, which is the UI
                 // thread via OnAudioFileReady. Still under transcriptionSemaphore, so ordering
                 // relative to Decode/Dispose is unchanged.
-                await Task.Run(() => EnsureRecognizerLoaded(effectiveModelDir), cancellationToken).ConfigureAwait(false);
+                await Task.Run(() => EnsureRecognizerLoaded(
+                    effectiveModelDir,
+                    translateToEnglish,
+                    translationSourceLanguage), cancellationToken).ConfigureAwait(false);
 
-                ErrorLogger.LogWarning($"Parakeet: dir={Path.GetFileName(effectiveModelDir)}");
+                ErrorLogger.LogWarning(translateToEnglish
+                    ? $"Canary translation: source={translationSourceLanguage}, target=en, dir={Path.GetFileName(effectiveModelDir)}"
+                    : $"Parakeet: dir={Path.GetFileName(effectiveModelDir)}");
 
                 // 120s timeout — generous for long-form on slow CPUs.
                 using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
@@ -238,7 +364,7 @@ namespace VoiceLite.Services
                     using var wavReader = new WaveFileReader(audioStream);
                     if (wavReader.WaveFormat.SampleRate != 16000)
                     {
-                        ErrorLogger.LogWarning($"Unexpected sample rate {wavReader.WaveFormat.SampleRate}, Parakeet expects 16000");
+                        ErrorLogger.LogWarning($"Unexpected sample rate {wavReader.WaveFormat.SampleRate}, speech model expects 16000");
                     }
                     ISampleProvider provider = wavReader.ToSampleProvider();
                     if (wavReader.WaveFormat.Channels > 1)
@@ -255,7 +381,10 @@ namespace VoiceLite.Services
                 OfflineRecognizer rec;
                 lock (recognizerLock)
                 {
-                    rec = recognizer ?? throw new InvalidOperationException("Parakeet recognizer not loaded");
+                    rec = recognizer ?? throw new InvalidOperationException(
+                        translateToEnglish
+                            ? "Translation recognizer not loaded"
+                            : "Parakeet recognizer not loaded");
                 }
 
                 // OfflineRecognizer.Decode is blocking native code — wrap in Task.Run
@@ -293,7 +422,9 @@ namespace VoiceLite.Services
                 }
 
                 var totalTime = DateTime.Now - startTime;
-                ErrorLogger.LogWarning($"Transcription completed in {totalTime.TotalMilliseconds:F0}ms, result length: {finalResult.Length} chars");
+                ErrorLogger.LogWarning(
+                    $"{(translateToEnglish ? "Translation" : "Transcription")} completed in " +
+                    $"{totalTime.TotalMilliseconds:F0}ms, result length: {finalResult.Length} chars");
 
                 isProcessing = false;
                 return finalResult;
@@ -302,7 +433,9 @@ namespace VoiceLite.Services
             {
                 isProcessing = false;
                 throw new TimeoutException(
-                    "Transcription timed out after 120 seconds. Try speaking less or switching to the Speed preset.");
+                    translateToEnglish
+                        ? "Translation timed out after 120 seconds. Try a shorter recording."
+                        : "Transcription timed out after 120 seconds. Try speaking less or switching to the Speed preset.");
             }
             catch (OperationCanceledException)
             {
@@ -380,10 +513,15 @@ namespace VoiceLite.Services
         {
             try
             {
-                var modelDir = modelResolver.ResolveModelPath();
+                var modelDir = settings.TranslateToEnglish
+                    ? translationModelResolver.ResolveModelPath()
+                    : modelResolver.ResolveModelPath();
                 if (string.IsNullOrEmpty(modelDir) || !Directory.Exists(modelDir))
                 {
-                    TranscriptionError?.Invoke(this, new DirectoryNotFoundException("Parakeet model directory not found"));
+                    TranscriptionError?.Invoke(this, new DirectoryNotFoundException(
+                        settings.TranslateToEnglish
+                            ? "Translation model directory not found"
+                            : "Parakeet model directory not found"));
                     return false;
                 }
                 return true;
@@ -399,7 +537,10 @@ namespace VoiceLite.Services
         {
             try
             {
-                return $"Sherpa-ONNX {typeof(OfflineRecognizer).Assembly.GetName().Version} (Parakeet TDT v3)";
+                var engine = settings.TranslateToEnglish
+                    ? "Canary 180M Flash Translation"
+                    : "Parakeet TDT v3";
+                return $"Sherpa-ONNX {typeof(OfflineRecognizer).Assembly.GetName().Version} ({engine})";
             }
             catch
             {
@@ -444,6 +585,8 @@ namespace VoiceLite.Services
                 recognizer = null;
                 currentModelDir = null;
                 currentPreset = null;
+                currentTranslationMode = null;
+                currentTranslationSourceLanguage = null;
             }
 
             try { transcriptionSemaphore?.Dispose(); }

--- a/VoiceLite/VoiceLite/Services/TranslationModelResolverService.cs
+++ b/VoiceLite/VoiceLite/Services/TranslationModelResolverService.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace VoiceLite.Services
+{
+    /// <summary>
+    /// Resolves the optional local Canary speech-translation model. Unlike Parakeet,
+    /// this model is not required at startup and is downloaded only when a user opts in.
+    /// </summary>
+    public class TranslationModelResolverService
+    {
+        public const string ModelId = "canary-180m-flash-en-es-de-fr-int8";
+        public const string ModelFolderName = "canary-translation";
+
+        public static readonly string[] RequiredModelFiles =
+        {
+            "encoder.int8.onnx",
+            "decoder.int8.onnx",
+            "tokens.txt"
+        };
+
+        private readonly IReadOnlyList<string> modelPaths;
+
+        public TranslationModelResolverService(
+            string? baseDirectory = null,
+            string? localAppDataDirectory = null)
+        {
+            var baseDir = baseDirectory ?? AppDomain.CurrentDomain.BaseDirectory;
+            var localAppData = localAppDataDirectory ??
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+            modelPaths = new[]
+            {
+                Path.Combine(baseDir, "models", ModelFolderName),
+                Path.Combine(baseDir, "translation", ModelFolderName),
+                Path.Combine(localAppData, "VoiceLite", "models", ModelFolderName)
+            };
+        }
+
+        public static string DefaultModelDirectory => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "VoiceLite", "models", ModelFolderName);
+
+        public IEnumerable<string> GetAvailableModelPaths() => modelPaths;
+
+        public string ResolveModelPath()
+        {
+            var modelPath = modelPaths.FirstOrDefault(HasRequiredFiles);
+            if (modelPath != null)
+                return modelPath;
+
+            throw new FileNotFoundException(
+                "The English translation model is not installed. " +
+                "Open Settings > General > Translate to English and click Install translation model.");
+        }
+
+        public bool IsModelInstalled() => modelPaths.Any(HasRequiredFiles);
+
+        public static bool HasRequiredFiles(string directory)
+        {
+            if (!Directory.Exists(directory))
+                return false;
+
+            return RequiredModelFiles.All(fileName =>
+            {
+                var file = new FileInfo(Path.Combine(directory, fileName));
+                return file.Exists && file.Length > 0;
+            });
+        }
+    }
+}

--- a/VoiceLite/VoiceLite/SettingsWindowNew.xaml
+++ b/VoiceLite/VoiceLite/SettingsWindowNew.xaml
@@ -123,8 +123,8 @@
                             </StackPanel>
                         </GroupBox>
 
-                        <!-- Optional offline speech translation -->
-                        <GroupBox Header="Translate to English" Margin="0,0,0,15">
+                        <!-- Optional offline speech translation (Pro) -->
+                        <GroupBox Name="TranslationGroupBox" Header="Translate to English (Pro)" Margin="0,0,0,15">
                             <StackPanel Margin="10">
                                 <CheckBox Name="TranslateToEnglishCheckBox"
                                           Content="Translate my speech to English"

--- a/VoiceLite/VoiceLite/SettingsWindowNew.xaml
+++ b/VoiceLite/VoiceLite/SettingsWindowNew.xaml
@@ -123,6 +123,48 @@
                             </StackPanel>
                         </GroupBox>
 
+                        <!-- Optional offline speech translation -->
+                        <GroupBox Header="Translate to English" Margin="0,0,0,15">
+                            <StackPanel Margin="10">
+                                <CheckBox Name="TranslateToEnglishCheckBox"
+                                          Content="Translate my speech to English"
+                                          Margin="0,0,0,8"
+                                          Checked="TranslateToEnglishCheckBox_Changed"
+                                          Unchecked="TranslateToEnglishCheckBox_Changed"
+                                          ToolTip="Uses a separate local translation model. Audio stays on this computer."/>
+
+                                <StackPanel Name="TranslationOptionsPanel" IsEnabled="False" Margin="20,0,0,0">
+                                    <TextBlock Text="Spoken language:" Margin="0,0,0,5"/>
+                                    <ComboBox Name="TranslationSourceLanguageComboBox"
+                                              MaxWidth="260"
+                                              HorizontalAlignment="Left"
+                                              Margin="0,0,0,8">
+                                        <ComboBoxItem Content="Spanish" Tag="es" IsSelected="True"/>
+                                        <ComboBoxItem Content="French" Tag="fr"/>
+                                        <ComboBoxItem Content="German" Tag="de"/>
+                                    </ComboBox>
+
+                                    <TextBlock Text="VoiceLite will insert the English translation instead of the original-language transcript. Translation runs locally and requires an optional ~154MB model."
+                                               TextWrapping="Wrap"
+                                               Foreground="Gray"
+                                               FontSize="11"
+                                               Margin="0,0,0,8"/>
+
+                                    <StackPanel Orientation="Horizontal">
+                                        <Button Name="InstallTranslationModelButton"
+                                                Content="Install translation model"
+                                                Width="175"
+                                                Margin="0,0,10,0"
+                                                Click="InstallTranslationModelButton_Click"/>
+                                        <TextBlock Name="TranslationModelStatusText"
+                                                   Text="Checking model..."
+                                                   VerticalAlignment="Center"
+                                                   FontSize="11"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </StackPanel>
+                        </GroupBox>
+
                         <!-- Audio Settings -->
                         <GroupBox Header="Audio Settings" Margin="0,0,0,15">
                             <StackPanel Margin="10">
@@ -257,7 +299,7 @@
                                    Margin="0,0,0,20"
                                    FontSize="12">
                             <Run Text="VoiceLite v2.0 uses NVIDIA Parakeet TDT 0.6B v3 via Sherpa-ONNX — a single multilingual model that runs locally on your CPU. "/>
-                            <Run Text="The model (~640MB) downloads on first launch and is shared across all users on this machine. Use the controls below to re-download or verify the model files."/>
+                            <Run Text="The main model (~640MB) downloads on first launch and is shared across all users on this machine. The optional Canary add-on enables local Spanish, French, or German speech translation to English. Use the controls below to install or verify model files."/>
                         </TextBlock>
 
                         <!-- Model Download Control -->

--- a/VoiceLite/VoiceLite/SettingsWindowNew.xaml.cs
+++ b/VoiceLite/VoiceLite/SettingsWindowNew.xaml.cs
@@ -91,7 +91,7 @@ namespace VoiceLite
                 ModelDownloadControl?.Initialize(
                     settings,
                     () => saveSettingsCallback?.Invoke(),
-                    includeTranslationModel: true);
+                    includeTranslationModel: proFeatureService?.IsProUser == true);
 
                 // Load Custom Shortcuts
                 LoadShortcuts();
@@ -144,6 +144,9 @@ namespace VoiceLite
 
             // Custom Dictionary tab — Pro-only feature
             CustomDictionaryTab.Visibility = proFeatureService.CustomDictionaryTabVisibility;
+
+            // Translate to English — Pro-only feature (runtime gate in TranscriptionService)
+            TranslationGroupBox.Visibility = proFeatureService.SpeechTranslationVisibility;
 
             // Future: Add more Pro feature visibility controls here
             // Example:
@@ -473,6 +476,11 @@ namespace VoiceLite
 
         private bool CanSaveTranslationSettings()
         {
+            // Free tier: the toggle is hidden and the runtime gate ignores the setting,
+            // so never block saving (a hand-edited settings.json could leave it checked).
+            if (proFeatureService?.IsProUser != true)
+                return true;
+
             if (TranslateToEnglishCheckBox.IsChecked != true ||
                 new TranslationModelResolverService().IsModelInstalled())
             {
@@ -520,7 +528,7 @@ namespace VoiceLite
             ModelDownloadControl?.Initialize(
                 settings,
                 () => saveSettingsCallback?.Invoke(),
-                includeTranslationModel: true);
+                includeTranslationModel: proFeatureService?.IsProUser == true);
         }
 
         private async Task TrackAnalyticsChangesAsync() { await Task.CompletedTask; }
@@ -593,7 +601,7 @@ namespace VoiceLite
                     ModelDownloadControl?.Initialize(
                         settings,
                         () => saveSettingsCallback?.Invoke(),
-                        includeTranslationModel: true);
+                        includeTranslationModel: proFeatureService?.IsProUser == true);
 
                     // Show success message
                     MessageBox.Show(

--- a/VoiceLite/VoiceLite/SettingsWindowNew.xaml.cs
+++ b/VoiceLite/VoiceLite/SettingsWindowNew.xaml.cs
@@ -67,6 +67,9 @@ namespace VoiceLite
                 // Transcription Preset
                 LoadTranscriptionPreset();
 
+                // Optional offline speech translation
+                LoadTranslationSettings();
+
                 // Audio Settings
                 LoadMicrophones();
                 if (AutoPasteCheckBox != null)
@@ -85,7 +88,10 @@ namespace VoiceLite
 
                 // Initialize Model Download Control (applies Pro gating for both free and Pro users)
                 // CRITICAL FIX: Must initialize for ALL users to apply visibility gating
-                ModelDownloadControl?.Initialize(settings, () => saveSettingsCallback?.Invoke());
+                ModelDownloadControl?.Initialize(
+                    settings,
+                    () => saveSettingsCallback?.Invoke(),
+                    includeTranslationModel: true);
 
                 // Load Custom Shortcuts
                 LoadShortcuts();
@@ -340,6 +346,9 @@ namespace VoiceLite
 
         private void ApplyButton_Click(object sender, RoutedEventArgs e)
         {
+            if (!CanSaveTranslationSettings())
+                return;
+
             SaveSettings();
             saveSettingsCallback?.Invoke(); // CRITICAL FIX: Persist settings to disk immediately
             StatusText.Text = "Settings applied successfully";
@@ -347,6 +356,9 @@ namespace VoiceLite
 
         private void SaveButton_Click(object sender, RoutedEventArgs e)
         {
+            if (!CanSaveTranslationSettings())
+                return;
+
             SaveSettings();
             saveSettingsCallback?.Invoke(); // CRITICAL FIX: Persist settings to disk immediately
 
@@ -389,6 +401,14 @@ namespace VoiceLite
             // VAD Settings
             settings.EnableVAD = EnableVADCheckBox.IsChecked ?? true;
 
+            // Optional offline speech translation
+            settings.TranslateToEnglish = TranslateToEnglishCheckBox.IsChecked ?? false;
+            if (TranslationSourceLanguageComboBox.SelectedItem is ComboBoxItem selectedLanguage &&
+                selectedLanguage.Tag is string sourceLanguage)
+            {
+                settings.TranslationSourceLanguage = sourceLanguage;
+            }
+
             // Audio Settings
             settings.AutoPaste = AutoPasteCheckBox.IsChecked ?? true;
 
@@ -407,6 +427,100 @@ namespace VoiceLite
             // Audio Enhancement - already saved via event handlers, no need to duplicate
 
             // Hotkey (already saved on change)
+        }
+
+        private void LoadTranslationSettings()
+        {
+            TranslateToEnglishCheckBox.IsChecked = settings.TranslateToEnglish;
+
+            foreach (var item in TranslationSourceLanguageComboBox.Items.OfType<ComboBoxItem>())
+            {
+                if (string.Equals(
+                    item.Tag?.ToString(),
+                    settings.TranslationSourceLanguage,
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    TranslationSourceLanguageComboBox.SelectedItem = item;
+                    break;
+                }
+            }
+
+            UpdateTranslationControls();
+        }
+
+        private void TranslateToEnglishCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            UpdateTranslationControls();
+        }
+
+        private void UpdateTranslationControls()
+        {
+            if (TranslationOptionsPanel == null)
+                return;
+
+            var enabled = TranslateToEnglishCheckBox?.IsChecked == true;
+            TranslationOptionsPanel.IsEnabled = enabled;
+
+            var installed = new TranslationModelResolverService().IsModelInstalled();
+            TranslationModelStatusText.Text = installed ? "✓ Installed" : "Not installed";
+            TranslationModelStatusText.Foreground = installed
+                ? System.Windows.Media.Brushes.Green
+                : System.Windows.Media.Brushes.DarkOrange;
+            InstallTranslationModelButton.Visibility = installed
+                ? Visibility.Collapsed
+                : Visibility.Visible;
+        }
+
+        private bool CanSaveTranslationSettings()
+        {
+            if (TranslateToEnglishCheckBox.IsChecked != true ||
+                new TranslationModelResolverService().IsModelInstalled())
+            {
+                return true;
+            }
+
+            MessageBox.Show(
+                "Install the translation model before enabling Translate to English.",
+                "Translation Model Required",
+                MessageBoxButton.OK,
+                MessageBoxImage.Information);
+            return false;
+        }
+
+        private void InstallTranslationModelButton_Click(object sender, RoutedEventArgs e)
+        {
+            var control = new Controls.ModelDownloadControl();
+            control.ShowTranslationModelOnly();
+
+            var window = new Window
+            {
+                Title = "VoiceLite — Translation Model",
+                Width = 720,
+                Height = 430,
+                Owner = this,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                ResizeMode = ResizeMode.NoResize,
+                Content = new ScrollViewer
+                {
+                    HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+                    VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                    Padding = new Thickness(20),
+                    Content = control
+                }
+            };
+
+            control.InstallCompleted += (_, _) =>
+            {
+                window.DialogResult = true;
+                window.Close();
+            };
+
+            window.ShowDialog();
+            UpdateTranslationControls();
+            ModelDownloadControl?.Initialize(
+                settings,
+                () => saveSettingsCallback?.Invoke(),
+                includeTranslationModel: true);
         }
 
         private async Task TrackAnalyticsChangesAsync() { await Task.CompletedTask; }
@@ -476,7 +590,10 @@ namespace VoiceLite
                     UpdateProFeatureVisibility();
 
                     // CRIT-4 FIX: Initialize Model Download Control with null check (consistent with line 93)
-                    ModelDownloadControl?.Initialize(settings, () => saveSettingsCallback?.Invoke());
+                    ModelDownloadControl?.Initialize(
+                        settings,
+                        () => saveSettingsCallback?.Invoke(),
+                        includeTranslationModel: true);
 
                     // Show success message
                     MessageBox.Show(

--- a/docs/audit/ARCHITECTURE.md
+++ b/docs/audit/ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 *Audit date: 2026-07-17. Reflects HEAD `09af732` (v2.1.2), branch `v2.0.0-parakeet-migration` which is byte-identical to `master`. Trust this over the root `ARCHITECTURE.md` and `PILOT.md`, both of which describe the deleted pre-v2.0 Whisper.net architecture.*
 
+*Updated 2026-07-20 for the optional local Canary speech-to-English translation path.*
+
 ## What actually ships
 
 **One product: the .NET 8 WPF desktop app** in `VoiceLite/VoiceLite/`, plus a Next.js licensing backend in `voicelite-web/`. Everything else in the repo is dead weight (see HEALTH.md / COMPLEXITY.md):
@@ -29,8 +31,9 @@ No DI container. `App.xaml.cs` runs a 3-stage startup gate, then `new MainWindow
 
 | Service | Role | Note |
 |---|---|---|
-| `PersistentWhisperService` | In-process ASR via Sherpa-ONNX `OfflineRecognizer` (Parakeet). | **Name is a lie — no Whisper anywhere.** |
+| `TranscriptionService` | In-process speech recognition via Parakeet, or opt-in speech-to-English translation via Canary 180M Flash. | Both paths use Sherpa-ONNX `OfflineRecognizer`; translation is off by default. |
 | `ModelResolverService` | Probes 3 dirs for the 4 Parakeet ONNX files. | `modelName` param is dead. |
+| `TranslationModelResolverService` | Probes for the optional 3-file Canary int8 model. | Spanish/French/German → English; downloaded only when enabled. |
 | `AudioRecorder` | NAudio 16k/mono capture → memory buffer → preprocessing + VAD → temp WAV. | Preprocessing/VAD live **here**, not in the whisper service. |
 | `TextInjector` | Clipboard write + simulated Ctrl+V on an STA worker thread; auto-clear timers. | Raw Win32 — no InputSimulator dependency (contra old docs). |
 | `LicenseService` | HTTP validation vs voicelite.app + DPAPI storage of `key\|email`. | Static HttpClient, intentionally not disposed. |
@@ -56,7 +59,9 @@ Hotkey (HotkeyManager: RegisterHotKey / GetAsyncKeyState)
        └ SaveMemoryBufferToTempFile(): HighPassFilter → NoiseGate → AGC → Silero VAD trim (threshold 0.35, HARDCODED)
          → temp WAV → fires AudioFileReady
   → MainWindow.OnAudioFileReady
-  → PersistentWhisperService.TranscribeAsync(path)
+  → TranscriptionService.TranscribeAsync(path)
+       ├ default: Parakeet v3 multilingual transcription
+       └ TranslateToEnglish: Canary 180M Flash (selected es/fr/de source → English)
        └ WaveFileReader.ToSampleProvider() → float[] → OfflineRecognizer.Decode()  [blocking native, wrapped in Task.Run]
   → TextPostProcessor.Process()  [punctuation, dev-terms, custom dictionary — dictionary Pro-gated since 2026-07-18]
   → CustomShortcutService.ProcessShortcuts()
@@ -64,9 +69,9 @@ Hotkey (HotkeyManager: RegisterHotKey / GetAsyncKeyState)
     else:                   TextInjector.CopyToClipboardForManualPaste()  [clipboard only, 30 s hold]
 ```
 
-Model resolution: `PersistentWhisperService` → `ModelResolverService` probes `models/parakeet-v3`, `whisper/parakeet-v3`, `%LocalAppData%/VoiceLite/models/parakeet-v3` for `encoder/decoder/joiner.int8.onnx` + `tokens.txt`.
+Model resolution: `TranscriptionService` → `ModelResolverService` probes `models/parakeet-v3`, `whisper/parakeet-v3`, `%LocalAppData%/VoiceLite/models/parakeet-v3` for `encoder/decoder/joiner.int8.onnx` + `tokens.txt`. When translation is enabled, `TranslationModelResolverService` instead resolves `models/canary-translation` containing `encoder/decoder.int8.onnx` + `tokens.txt`.
 
-Local state (all under `%LOCALAPPDATA%\VoiceLite\`, never Roaming): `settings.json` (prefs + history), `license.dat` (DPAPI `key|email`), `logs\`, `models\parakeet-v3\`.
+Local state (all under `%LOCALAPPDATA%\VoiceLite\`, never Roaming): `settings.json` (prefs + history), `license.dat` (DPAPI `key|email`), `logs\`, `models\parakeet-v3\`, and optional `models\canary-translation\`.
 
 ## Web backend: components
 

--- a/docs/audit/ARCHITECTURE.md
+++ b/docs/audit/ARCHITECTURE.md
@@ -31,7 +31,7 @@ No DI container. `App.xaml.cs` runs a 3-stage startup gate, then `new MainWindow
 
 | Service | Role | Note |
 |---|---|---|
-| `TranscriptionService` | In-process speech recognition via Parakeet, or opt-in speech-to-English translation via Canary 180M Flash. | Both paths use Sherpa-ONNX `OfflineRecognizer`; translation is off by default. |
+| `TranscriptionService` | In-process speech recognition via Parakeet, or opt-in speech-to-English translation via Canary 180M Flash. | Both paths use Sherpa-ONNX `OfflineRecognizer`; translation is off by default and Pro-gated (`EffectiveTranslateToEnglish`). |
 | `ModelResolverService` | Probes 3 dirs for the 4 Parakeet ONNX files. | `modelName` param is dead. |
 | `TranslationModelResolverService` | Probes for the optional 3-file Canary int8 model. | Spanish/French/German → English; downloaded only when enabled. |
 | `AudioRecorder` | NAudio 16k/mono capture → memory buffer → preprocessing + VAD → temp WAV. | Preprocessing/VAD live **here**, not in the whisper service. |


### PR DESCRIPTION
## Summary

Adds an opt-in, fully local speech-to-English translation mode for Spanish, French, and German using NVIDIA Canary 180M Flash through the existing Sherpa-ONNX runtime.

Normal Parakeet transcription remains the default, so existing users see no behavior change unless they enable translation.

## Changes

- Add persisted Translate to English and source-language settings, with an explicit General-settings UI.
- Add an optional ~154 MB Canary int8 downloader, atomic extraction, model resolution, and CC-BY-4.0 attribution.
- Route translation through the existing protected TranscriptionService semaphore, Task.Run decode, cancellation, reload, and disposal lifecycle.
- Record the translation model in history and surface actionable missing-model/translation errors.
- Add settings, resolver, config, compatibility, and optional real-model functional coverage.
- Update README and audited architecture documentation.

## Review

Reviewed for default/upgrade compatibility, offline privacy, model-download safety, source-language task tokens, recognizer reload keys, cancellation, and native disposal ordering. Review findings were fixed before commit; no unresolved findings remain.

## Testing

- [x] Ran `dotnet build VoiceLite/VoiceLite.sln`
- [x] Ran `dotnet test VoiceLite/VoiceLite.Tests/VoiceLite.Tests.csproj` — 333 passed, 22 skipped, 0 failed
- [x] Tested the real Canary int8 model on Windows with Sherpa's German sample; the app path returned English successfully
- [x] Confirmed temporary model smoke-test assets were removed

## Checklist

- [x] Code follows existing patterns
- [x] No new warnings introduced (the build retains five pre-existing nullable warnings)
- [ ] Updated CHANGELOG.md — intentionally not updated because the repository audit marks the root changelog as stale; README and `docs/audit/ARCHITECTURE.md` are updated instead